### PR TITLE
feat(types): add py.typed marker per PEP 561

### DIFF
--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,10 @@
+"""Packaging smoke tests — verify PEP 561 typing marker is distributed."""
+
+from __future__ import annotations
+
+import importlib.resources
+
+
+def test_py_typed_marker_is_shipped() -> None:
+    marker = importlib.resources.files("pretensor").joinpath("py.typed")
+    assert marker.is_file()


### PR DESCRIPTION
Mark pretensor as a typed package so downstream consumers (pyright, mypy) pick up inline annotations across the import boundary instead of treating every `pretensor.*` symbol as Any.

Hatchling includes the empty marker automatically via the existing `packages = ["src/pretensor"]` wheel config — verified by inspecting the built wheel. A smoke test asserts the marker ships with the package via `importlib.resources`.

## Summary

<!-- What changed and why (1-3 sentences). -->

## Checklist

- [x] Tests pass (`python -m pytest tests/`)
- [x] Linting passes (`ruff check src/ tests/`)
- [x] Type checking passes (`pyright src/`)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (or noted as not user-facing)
- [x] All commits signed off per the [Developer Certificate of Origin](https://developercertificate.org/) (`git commit -s`)

## Notes

