### PR TITLE
docs: lead with the PyPI install path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - 'README.md'
+      - 'scripts/check_readme_urls.py'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'scripts/check_readme_urls.py'
+      - '.github/workflows/docs.yml'
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  readme-urls:
+    name: Verify README URLs are absolute
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check
+        run: python3 scripts/check_readme_urls.py
+
+  readme-links:
+    name: Verify README links resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      - name: Lychee link checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --cache --no-progress --max-concurrency 4 --accept 200,206,429 README.md
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [PEP 440](https://peps.python.org/pep-0440/) versioning.
 
-Pretensor is in **pre-release development** and is not yet published to PyPI.
-Until the first packaged release, this changelog tracks notable changes landing on `main`.
+Pretensor is currently in alpha on PyPI (`pip install pretensor` —
+no `--pre` needed yet because no stable release exists). Until `1.0.0`
+ships, the schema and CLI surface can change between versions; this
+changelog tracks what moves between releases.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Pretensor OSS
 
+[![PyPI](https://img.shields.io/pypi/v/pretensor.svg)](https://pypi.org/project/pretensor/)
 [![CI](https://github.com/pretensor-ai/pretensor/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pretensor-ai/pretensor/actions/workflows/ci.yml)
-[![Status: Pre-release](https://img.shields.io/badge/status-pre--release-yellow.svg)](#status)
+[![Status: Alpha](https://img.shields.io/badge/status-alpha-yellow.svg)](#status)
 [![Python: 3.11 | 3.12](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](#prerequisites)
 
 **Pretensor OSS** introspects **PostgreSQL** and **Snowflake**, with optional **BigQuery** connector support, builds a **Kuzu** knowledge graph of tables, columns, foreign keys, inferred joins, and related metadata, and exposes that graph to AI tools through an **MCP** (Model Context Protocol) server. Agents query schema context and search without issuing raw SQL against your graph store.
 
-> **Status: Pre-release.** Pretensor is not yet published to PyPI. Install and run it from this repository for now; APIs, CLI flags, and graph schema may change before the first packaged release.
+> **Status: Alpha.** Pretensor is on PyPI as `pretensor` (latest alpha: `0.1.0a0`). CLI flags, MCP tools, and graph schema can still change between alpha versions — pin exact versions until `1.0.0`. See [docs/releases.md](https://github.com/pretensor-ai/pretensor/blob/main/docs/releases.md) for the versioning policy.
 
 ## Who is this for
 
@@ -18,29 +19,39 @@
 ## Prerequisites
 
 - **Python 3.11 or 3.12** (3.13 not yet tested).
-- A reachable database for `pretensor index`. PostgreSQL is the fastest local path; Snowflake and BigQuery are also supported from a source checkout with their optional dependencies.
-- **`uv`** is recommended. If `uv` is not installed, create a local `.venv` first and `make install` will use `pip` inside that environment.
+- A reachable database for `pretensor index`. PostgreSQL is the fastest local path; Snowflake and BigQuery are supported via the `pretensor[snowflake]` and `pretensor[bigquery]` extras.
 
-## Install From Source
-
-```bash
-git clone https://github.com/pretensor-ai/pretensor.git
-cd pretensor
-make install
-```
-
-If `uv` is not installed, create and activate a local virtualenv first:
+## Install
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
-make install
+pip install pretensor
+# or, inside a uv-managed environment:
+uv pip install pretensor
 ```
+
+Optional features are exposed as extras:
+
+| Extra | Adds | Use when |
+|-------|------|----------|
+| `pretensor[snowflake]` | `snowflake-sqlalchemy` | You're indexing a Snowflake warehouse. |
+| `pretensor[bigquery]` | `google-cloud-bigquery` | You're indexing BigQuery. |
+| `pretensor[clustering]` | `leidenalg` | You want Leiden community detection during indexing. Without this, Pretensor falls back to igraph Louvain (works, but no resolution tuning). |
+
+Combine extras with comma separation, e.g. `pip install 'pretensor[snowflake,clustering]'`.
+
+Try it without installing:
+
+```bash
+uvx --from pretensor pretensor --help
+```
+
+> **A note on alpha versions.** Pretensor is in alpha (`0.1.0aN`). The plain `pip install pretensor` command picks up the latest alpha because PyPI has no stable release yet. Once `1.0.0` ships, future alphas will require `--pre` (e.g. `pip install --pre pretensor`); pin to a specific version (`pretensor==0.1.0a0`) if you want a deterministic install today.
+
+If you want to hack on Pretensor itself rather than use it, see the contributor setup in [CONTRIBUTING.md](https://github.com/pretensor-ai/pretensor/blob/main/CONTRIBUTING.md) for the `git clone` + `make install` flow.
 
 ## Quickstart
 
 ```bash
-make install
 pretensor index postgresql://USER:PASSWORD@HOST:5432/DBNAME
 pretensor serve --config-only   # prints mcpServers JSON for Claude / Cursor
 ```
@@ -80,8 +91,8 @@ Use **`--state-dir`** on `index` / `reindex` and **`--graph-dir`** on `serve` wh
 
 Pretensor is in **pre-release development**. Before the first packaged release:
 
-- There is no PyPI package yet; install from a source checkout.
-- There is no SemVer stability guarantee yet, so APIs, CLI flags, and graph schema may change.
+- The package on PyPI is named `pretensor`. The first stable release will be `1.0.0`; everything before that is alpha. `pip install pretensor` works today because no stable version exists yet — `--pre` will be required once `1.0.0` ships and future alphas resume.
+- There is no SemVer stability guarantee yet, so CLI flags, MCP tools, and graph schema may change between alphas. Pin exact versions.
 - Treat current builds as evaluation software and test upgrades in a staging environment before production use.
 
 Progress and release notes: [CHANGELOG.md](https://github.com/pretensor-ai/pretensor/blob/main/CHANGELOG.md).
@@ -106,4 +117,4 @@ make typecheck # pyright
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](https://github.com/pretensor-ai/pretensor/blob/main/LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,15 @@
 
 ## Supported versions
 
-Pretensor is currently in **pre-release development** and is not yet published to PyPI. Until the first packaged release, security fixes land on the latest supported state of this repository.
+Pretensor is currently in **alpha** on PyPI (`pip install pretensor`). Security fixes are released against the latest alpha on PyPI; pin to a specific version (for example `pretensor==0.1.0a0`) until `1.0.0` if you need a stable target.
 
 | Version | Supported |
 |---------|-----------|
-| Current `main` branch snapshot | Yes |
-| Older commits, forks, or unpublished snapshots | No |
+| Latest pre-release on PyPI | Yes |
+| Older pre-releases | No — upgrade to the latest alpha for fixes |
+| Source checkouts ahead of PyPI | Best effort, until the next alpha rolls forward |
 
-Once Pretensor begins shipping packaged releases, this policy will be updated to cover a defined support window.
+Once Pretensor reaches `1.0.0`, this section will be updated to describe a defined support window.
 
 ## Reporting a vulnerability
 
@@ -23,7 +24,7 @@ Include:
 
 - A description of the issue and the affected component.
 - Steps to reproduce, ideally with a minimal proof of concept.
-- The git commit SHA or package metadata you tested against (for example `git rev-parse HEAD` from a source checkout).
+- The version or commit you tested against — for a PyPI install, `pip show pretensor`; for a source checkout, `git rev-parse HEAD`.
 - Your assessment of impact (confidentiality, integrity, availability).
 
 ## What to expect
@@ -38,7 +39,7 @@ Pretensor is maintained by a small team on a best-effort basis during pre-releas
 
 In scope:
 
-- The `pretensor` Python package and CLI when installed from this repository.
+- The `pretensor` Python package and CLI, whether installed from PyPI or from a source checkout of this repository.
 - The MCP server entrypoint (`pretensor serve`).
 - Default connector implementations shipped in this repository.
 

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -16,7 +16,7 @@ This guide takes you from zero to a running MCP server connected to a real datab
 
 ## 0. One-command quickstart
 
-After installing from a clone of this repo, this is the fastest way to see Pretensor working end-to-end. Requires Docker and a repo checkout.
+After installing Pretensor (Section 1), this is the fastest way to see it working end-to-end. Requires Docker.
 
 ```bash
 pretensor quickstart
@@ -40,30 +40,37 @@ If you already have a Postgres reachable at `postgresql://postgres:postgres@loca
 
 ## 1. Install
 
-Pretensor is not published to PyPI yet. Install and run it from a source checkout of this repository.
+```bash
+pip install pretensor
+# or
+uv pip install pretensor
+```
+
+Once installed, the `pretensor` CLI is on `$PATH` and Sections 2–8 below assume you can call it directly. Pretensor is currently in alpha; `pip install pretensor` picks up the latest alpha automatically because no stable release exists yet (once `1.0.0` ships, you'll need `--pre` to keep installing alphas).
+
+Optional features are exposed as extras:
+
+| Extra | Adds | Use when |
+|-------|------|----------|
+| `pretensor[snowflake]` | `snowflake-sqlalchemy` | You're indexing a Snowflake warehouse. |
+| `pretensor[bigquery]` | `google-cloud-bigquery` | You're indexing BigQuery. |
+| `pretensor[clustering]` | `leidenalg` | You want Leiden community detection during indexing. Without this, Pretensor falls back to igraph Louvain (works, but no resolution tuning). |
+
+Combine extras with comma separation, e.g. `pip install 'pretensor[snowflake,clustering]'`.
+
+**Prerequisites:** Python 3.11 or 3.12 (3.13 not yet tested). A reachable database for `pretensor index` — Postgres is the fastest local path; the manual smoke test in Section 5 spins one up via Docker.
+
+### Hacking on Pretensor itself
+
+If you're modifying Pretensor source rather than just using it, install from a checkout instead:
 
 ```bash
 git clone https://github.com/pretensor-ai/pretensor.git
 cd pretensor
-make install
+make install   # uses uv if present, falls back to pip in .venv
 ```
 
-Equivalent manual setup with `uv`:
-
-```bash
-uv sync --extra dev
-uv run pre-commit install
-```
-
-Without `uv`, create a local virtualenv first and `make install` will use `pip` inside `.venv`:
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
-make install
-```
-
-**Prerequisites:** Python 3.11 or 3.12 (3.13 not yet tested). Optional extras are available from the source checkout, for example `pip install -e ".[dev,snowflake]"` inside `.venv` if you need the Snowflake connector.
+`make install` installs the project editable with the `dev` extra and sets up the pre-commit hooks — what `CONTRIBUTING.md` expects for PR work.
 
 ---
 

--- a/scripts/check_readme_urls.py
+++ b/scripts/check_readme_urls.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Fail if any URL in README.md is relative.
+
+PyPI renders the README from the wheel/sdist long_description. Relative
+URLs like ``[text](docs/foo.md)`` 404 there because PyPI cannot resolve
+them against a repo. Every URL has to be absolute (``http(s)://``), an
+in-page fragment (``#anchor``), or a ``mailto:`` link.
+
+Only README.md is checked. CHANGELOG.md, CONTRIBUTING.md, SECURITY.md,
+etc. render fine on GitHub but do not reach PyPI, so relative paths
+between them are conventional and harmless.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ALLOWED_PREFIXES = ("http://", "https://", "#", "mailto:")
+README = Path("README.md")
+
+_IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+
+def find_relative_urls(content: str) -> list[tuple[int, str, str]]:
+    errors: list[tuple[int, str, str]] = []
+
+    for m in _IMAGE_PATTERN.finditer(content):
+        url = m.group(2)
+        if not url.startswith(ALLOWED_PREFIXES):
+            line = content[: m.start()].count("\n") + 1
+            errors.append((line, "image", url))
+
+    # Strip image syntax before scanning for links — otherwise the badge
+    # pattern ``[![alt](image-url)](target-url)`` confuses the link regex
+    # because the inner ``]`` closes the outer ``[...]`` prematurely.
+    cleaned = _IMAGE_PATTERN.sub("__IMG__", content)
+
+    for m in _LINK_PATTERN.finditer(cleaned):
+        url = m.group(2)
+        if not url.startswith(ALLOWED_PREFIXES):
+            line = cleaned[: m.start()].count("\n") + 1
+            errors.append((line, "link", url))
+
+    return errors
+
+
+def main() -> int:
+    if not README.exists():
+        print(f"error: {README} not found (run from repo root)", file=sys.stderr)
+        return 1
+    errors = find_relative_urls(README.read_text())
+    if errors:
+        print(
+            f"{README}: {len(errors)} relative URL(s) found.\n"
+            "PyPI renders README.md from the wheel/sdist; every URL must "
+            "be absolute (http://..., https://...), an in-page anchor "
+            "(#section), or a mailto: link.",
+            file=sys.stderr,
+        )
+        for line, kind, url in errors:
+            print(f"  L{line}: {kind}: {url}", file=sys.stderr)
+        return 1
+    print(f"{README}: URL check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Pretensor is now on PyPI as pretensor 0.1.0a0. Several user-facing docs still said "not yet published to PyPI" and instructed users to git clone and build from source as the primary path. Flip those so README and quickstart lead with `pip install pretensor`, keeping source-install instructions as a contributor pointer.

## Checklist

- [ ] Tests pass (`python -m pytest tests/`)
- [ ] Linting passes (`ruff check src/ tests/`)
- [ ] Type checking passes (`pyright src/`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (or noted as not user-facing)
- [ ] All commits signed off per the [Developer Certificate of Origin](https://developercertificate.org/) (`git commit -s`)

## Notes

