### PR TITLE
fix(packaging): drop embedding deps from [all-connectors] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,6 @@ bigquery = [
 all-connectors = [
     "snowflake-sqlalchemy>=1.5",
     "google-cloud-bigquery>=3.25",
-    "onnxruntime>=1.17",
-    "huggingface-hub>=0.20",
-    "numpy>=1.26",
-    "transformers>=4.38",
 ]
 clustering = [
     "leidenalg>=0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -1262,11 +1262,7 @@ dependencies = [
 [package.optional-dependencies]
 all-connectors = [
     { name = "google-cloud-bigquery" },
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
     { name = "snowflake-sqlalchemy" },
-    { name = "transformers" },
 ]
 bigquery = [
     { name = "google-cloud-bigquery" },
@@ -1312,16 +1308,13 @@ requires-dist = [
     { name = "google-cloud-bigquery", marker = "extra == 'all-connectors'", specifier = ">=3.25" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.25" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "huggingface-hub", marker = "extra == 'all-connectors'", specifier = ">=0.20" },
     { name = "huggingface-hub", marker = "extra == 'embeddings'", specifier = ">=0.20" },
     { name = "igraph", specifier = ">=0.11,<1" },
     { name = "kuzu", specifier = ">=0.7,<1" },
     { name = "leidenalg", marker = "extra == 'clustering'", specifier = ">=0.10" },
     { name = "mcp", specifier = ">=1.0" },
-    { name = "numpy", marker = "extra == 'all-connectors'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=1.26" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=1.26" },
-    { name = "onnxruntime", marker = "extra == 'all-connectors'", specifier = ">=1.17" },
     { name = "onnxruntime", marker = "extra == 'embeddings'", specifier = ">=1.17" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
@@ -1337,7 +1330,6 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlglot", specifier = ">=25.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'e2e'", specifier = ">=4.0" },
-    { name = "transformers", marker = "extra == 'all-connectors'", specifier = ">=4.38" },
     { name = "transformers", marker = "extra == 'embeddings'", specifier = ">=4.38" },
     { name = "typer", specifier = ">=0.12" },
 ]


### PR DESCRIPTION
The all-connectors extra previously bundled the embedding ML deps (onnxruntime, huggingface-hub, numpy, transformers) on top of the two real database connectors. The name suggests "all connectors," but the contents pulled hundreds of megabytes of ML wheels that no user-reachable code path consumes today — LocalEmbeddingClient is only instantiated in tests; no CLI flag, no indexing call site, no MCP tool reaches it.

Drop those four packages from [all-connectors] so the extra now delivers exactly what its name promises: snowflake-sqlalchemy + google-cloud-bigquery. The [embeddings] extra retains its full dep list and is the right opt-in once the wire-up work on a separate branch lands.

uv.lock refreshed to match — same packages still resolved (the embedding deps remain in the lockfile via [embeddings]), only the extra-membership annotations change.

## Checklist

- [ ] Tests pass (`python -m pytest tests/`)
- [ ] Linting passes (`ruff check src/ tests/`)
- [ ] Type checking passes (`pyright src/`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (or noted as not user-facing)
- [ ] All commits signed off per the [Developer Certificate of Origin](https://developercertificate.org/) (`git commit -s`)
