### PR TITLE
fix: resolve cypher thread leak using native kuzu timeout

### DIFF
--- a/src/pretensor/core/store.py
+++ b/src/pretensor/core/store.py
@@ -1325,6 +1325,13 @@ class KuzuStore:
         """Run a read query (or arbitrary Cypher) with optional parameters."""
         return self._conn.execute(cypher, parameters)
 
+    def set_query_timeout(self, timeout_ms: int) -> None:
+        """Set the query timeout value in ms for executing queries on this connection.
+
+        A value of ``0`` disables the timeout (default Kuzu behavior).
+        """
+        self._conn.set_query_timeout(timeout_ms)
+
     def query_all_rows(
         self, cypher: str, parameters: dict[str, Any] | None = None
     ) -> list[tuple[Any, ...]]:

--- a/src/pretensor/mcp/tools/cypher.py
+++ b/src/pretensor/mcp/tools/cypher.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import Any
 
@@ -88,11 +86,15 @@ def json_safe_cypher_value(value: Any) -> Any:
     return str(value)
 
 
-def _materialize_read_only_rows(graph_path: Path, q: str) -> list[dict[str, Any]]:
-    """Open DB, run Cypher, return row dicts (runs in a worker thread for timeouts)."""
+def _materialize_read_only_rows(
+    graph_path: Path, q: str, *, timeout_seconds: float
+) -> list[dict[str, Any]]:
+    """Open DB, run Cypher with a native Kuzu timeout, return row dicts."""
     store = KuzuStore(graph_path)
     try:
         store.ensure_schema()
+        timeout_ms = max(0, int(timeout_seconds * 1000))
+        store.set_query_timeout(timeout_ms)
         raw = store.execute(q)
         if isinstance(raw, list):
             raise TypeError("Unexpected multi-statement Cypher result")
@@ -313,11 +315,13 @@ def cypher_payload(
         return {"error": f"Graph file not found for database: {db!r}"}
 
     try:
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(_materialize_read_only_rows, graph_path, q)
-            rows = future.result(timeout=timeout_seconds)
-    except FutureTimeoutError:
-        return {"error": f"Query timed out after {timeout_seconds:g}s"}
+        rows = _materialize_read_only_rows(
+            graph_path, q, timeout_seconds=timeout_seconds
+        )
+    except RuntimeError as exc:
+        if "interrupted" in str(exc).lower():
+            return {"error": f"Query timed out after {timeout_seconds:g}s"}
+        return {"error": _enrich_kuzu_error(exc, q, graph_path)}
     except Exception as exc:
         return {"error": _enrich_kuzu_error(exc, q, graph_path)}
     vf = visibility_filter or get_effective_visibility_filter()

--- a/tests/mcp/test_error_handling.py
+++ b/tests/mcp/test_error_handling.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pretensor.core.store import KuzuStore
 from pretensor.mcp.tool_registry import McpTool, McpToolRegistry
 
 # ---------------------------------------------------------------------------
@@ -108,6 +109,69 @@ def test_open_store_for_entry_raises_on_corrupt_graph(tmp_path: Path) -> None:
     ):
         with pytest.raises(RuntimeError, match="Cannot open graph file"):
             open_store_for_entry(entry)
+
+
+# ---------------------------------------------------------------------------
+# Native Kuzu query timeout (no ThreadPoolExecutor leak)
+# ---------------------------------------------------------------------------
+
+
+def test_native_query_timeout_raises_interrupted(graph_store: KuzuStore) -> None:
+    """A query that exceeds the native Kuzu timeout must raise RuntimeError('Interrupted.')."""
+    graph_store.set_query_timeout(1)  # 1 ms — essentially instant timeout
+    with pytest.raises(RuntimeError, match="Interrupted"):
+        graph_store.execute("UNWIND range(1, 100000) AS a UNWIND range(1, 100000) AS b RETURN count(a)")
+
+
+def test_cypher_payload_uses_native_timeout(tmp_path: Path) -> None:
+    """The cypher tool must return a timeout error dict without spawning threads."""
+    from datetime import datetime, timezone
+
+    from pretensor.connectors.models import Column, SchemaSnapshot, Table
+    from pretensor.core.builder import GraphBuilder
+    from pretensor.core.registry import GraphRegistry
+    from pretensor.core.store import KuzuStore
+    from pretensor.mcp.tools.cypher import cypher_payload
+
+    graph = tmp_path / "graphs" / "demo.kuzu"
+    graph.parent.mkdir(parents=True)
+    store = KuzuStore(graph)
+    try:
+        snap = SchemaSnapshot(
+            connection_name="demo",
+            database="demo",
+            schemas=["public"],
+            tables=[
+                Table(
+                    name="orders",
+                    schema_name="public",
+                    columns=[Column(name="id", data_type="int")],
+                )
+            ],
+            introspected_at=datetime.now(timezone.utc),
+        )
+        GraphBuilder().build(snap, store, run_relationship_discovery=False)
+    finally:
+        store.close()
+
+    reg = GraphRegistry(tmp_path / "registry.json").load()
+    reg.upsert(
+        connection_name="demo",
+        database="demo",
+        dsn="postgresql://u@localhost/demo",
+        graph_path=graph,
+        indexed_at=datetime.now(timezone.utc),
+    )
+    reg.save()
+
+    result = cypher_payload(
+        tmp_path,
+        query="UNWIND range(1, 100000) AS a UNWIND range(1, 100000) AS b RETURN count(a)",
+        database="demo",
+        timeout_seconds=0.001,  # 1 ms
+    )
+    assert "error" in result
+    assert "timed out" in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "pretensor"
-version = "0.1.0a2"
+version = "0.1.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
src/pretensor/core/store.py
- Added a set_query_timeout(timeout_ms: int) method on KuzuStore that delegates to Kuzu's native Connection.set_query_timeout().
src/pretensor/mcp/tools/cypher.py
- Removed ThreadPoolExecutor and FutureTimeoutError imports entirely.
- Updated _materialize_read_only_rows to accept timeout_seconds, convert it to milliseconds, and call store.set_query_timeout() before executing the query.
- Replaced the with ThreadPoolExecutor(...) block in cypher_payload with a direct call to _materialize_read_only_rows.
- Added a RuntimeError catch that maps Kuzu's "Interrupted." message back to the existing timeout error dict: {"error": "Query timed out after Xs"}.
tests/mcp/test_error_handling.py
- Added test_native_query_timeout_raises_interrupted: asserts that a query with a 1 ms native timeout raises RuntimeError("Interrupted.").
- Added test_cypher_payload_uses_native_timeout: builds a real graph, calls cypher_payload with timeout_seconds=0.001, and asserts the returned error dict contains "timed out".
