### PR TITLE
feat: support snowflake private key file path in config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "pretensor": {
+      "type": "local",
+      "command": ["/home/maximo/Development/pretensor/.venv/bin/pretensor", "serve", "--graph-dir", "/home/maximo/Development/pretensor/.pretensor"],
+      "enabled": true
+    }
+  }
+}

--- a/src/pretensor/cli/config_file.py
+++ b/src/pretensor/cli/config_file.py
@@ -71,6 +71,8 @@ _SOURCE_ALLOWED_KEYS = frozenset(
         "schema",
         "warehouse",
         "role",
+        "private_key_path",
+        "private_key_passphrase",
         # BigQuery
         "project",
         "dataset",
@@ -94,6 +96,8 @@ class SourceConfig:
     schema: str | None = None
     warehouse: str | None = None
     role: str | None = None
+    private_key_path: str | None = None
+    private_key_passphrase: str | None = None
     # BigQuery
     project: str | None = None
     dataset: str | None = None
@@ -185,6 +189,7 @@ def _graph_config_from_mapping(raw: Any) -> GraphConfig:
 def _source_config_from_mapping(
     name: str,
     raw: Any,
+    base_dir: Path,
 ) -> SourceConfig:
     """Validate and build a :class:`SourceConfig` from a raw YAML mapping."""
     if not isinstance(raw, dict):
@@ -213,6 +218,7 @@ def _source_config_from_mapping(
         "project",
         "dataset",
         "location",
+        "private_key_passphrase",
     }
     kwargs: dict[str, Any] = {"dialect": dialect.strip().lower(), "port": port}
     for key in str_fields:
@@ -223,12 +229,19 @@ def _source_config_from_mapping(
             raise CliConfigError(f"Source `{name}`: `{key}` must be a string")
         else:
             kwargs[key] = val.strip() or None
+    # Resolve private_key_path relative to config file location
+    kwargs["private_key_path"] = _resolved_optional_path(
+        data.get("private_key_path"),
+        field="private_key_path",
+        base_dir=base_dir,
+    )
     return SourceConfig(**kwargs)
 
 
 def _parse_sources(
     raw: Any,
     secrets_raw: dict[str, Any] | None,
+    base_dir: Path,
 ) -> dict[str, SourceConfig]:
     """Parse the ``sources:`` block and merge optional secrets overlay."""
     mapping = _as_mapping(raw, field="sources")
@@ -247,7 +260,7 @@ def _parse_sources(
                 )
             if isinstance(merged, dict):
                 merged = {**merged, **secret_block}
-        sources[name.strip()] = _source_config_from_mapping(name.strip(), merged)
+        sources[name.strip()] = _source_config_from_mapping(name.strip(), merged, base_dir)
     return sources
 
 
@@ -329,7 +342,7 @@ def load_cli_config(config_path: Path | None) -> PretensorCliConfig:
     )
 
     secrets_raw = _load_secrets_file(base_dir)
-    sources = _parse_sources(raw.get("sources"), secrets_raw)
+    sources = _parse_sources(raw.get("sources"), secrets_raw, base_dir)
 
     return PretensorCliConfig(
         source_path=source,

--- a/src/pretensor/connectors/snowflake.py
+++ b/src/pretensor/connectors/snowflake.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -120,12 +124,76 @@ class SnowflakeConnector(BaseConnector):
             query_parts.append(f"role={quote(role, safe='')}")
 
         q = ("?" + "&".join(query_parts)) if query_parts else ""
+        # Key-pair auth takes precedence: omit password from URL when a
+        # private key is configured.
+        if cfg.private_key_path:
+            return f"snowflake://{user}@{account}{path}{q}"
         return f"snowflake://{user}:{password}@{account}{path}{q}"
+
+    def _load_private_key(self) -> bytes:
+        """Read and serialize the configured private key for Snowflake.
+
+        Returns the key as DER-encoded PKCS8 bytes suitable for the
+        Snowflake Python connector's ``private_key`` connect argument.
+
+        Raises:
+            SnowflakeConnectorError: If the file is missing, unreadable,
+                or the key cannot be parsed/decrypted.
+        """
+        cfg = self.config
+        key_path_str = cfg.private_key_path
+        if not key_path_str:
+            raise SnowflakeConnectorError("No private_key_path configured")
+
+        key_path = Path(key_path_str)
+        try:
+            pem_data = key_path.read_bytes()
+        except FileNotFoundError as exc:
+            raise SnowflakeConnectorError(
+                f"Private key file not found: {key_path}"
+            ) from exc
+        except OSError as exc:
+            raise SnowflakeConnectorError(
+                f"Cannot read private key file {key_path}: {exc}"
+            ) from exc
+
+        passphrase: bytes | None = None
+        if cfg.private_key_passphrase:
+            passphrase = cfg.private_key_passphrase.encode("utf-8")
+
+        try:
+            p_key = serialization.load_pem_private_key(
+                pem_data,
+                password=passphrase,
+                backend=default_backend(),
+            )
+        except Exception as exc:
+            raise SnowflakeConnectorError(
+                f"Failed to parse private key from {key_path}: {exc}"
+            ) from exc
+
+        try:
+            pkb = p_key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        except Exception as exc:
+            raise SnowflakeConnectorError(
+                f"Failed to serialize private key from {key_path}: {exc}"
+            ) from exc
+
+        return pkb
 
     def connect(self) -> None:
         url = self._snowflake_url()
+        connect_args: dict[str, Any] = {}
+        if self.config.private_key_path:
+            connect_args["private_key"] = self._load_private_key()
         try:
-            self._engine = create_engine(url, pool_pre_ping=True)
+            self._engine = create_engine(
+                url, pool_pre_ping=True, connect_args=connect_args
+            )
             with self._engine.connect() as conn:
                 conn.execute(text("SELECT 1"))
             logger.info(

--- a/src/pretensor/introspection/models/config.py
+++ b/src/pretensor/introspection/models/config.py
@@ -56,6 +56,8 @@ class ConnectionConfig(PretensorModel):
     database: str | None = None
     user: str | None = None
     password: str | None = None
+    private_key_path: str | None = None
+    private_key_passphrase: str | None = None
     schema_filter: SchemaFilter = Field(default_factory=SchemaFilter)
     metadata_extra: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/pretensor/introspection/models/dsn.py
+++ b/src/pretensor/introspection/models/dsn.py
@@ -303,6 +303,8 @@ def connection_config_from_source(
             database=source.database,
             user=source.user,
             password=source.password,
+            private_key_path=source.private_key_path,
+            private_key_passphrase=source.private_key_passphrase,
             schema_filter=_snowflake_schema_filter(sf_schema),
             metadata_extra={
                 "snowflake_schema": sf_schema,

--- a/tests/cli/test_config_file.py
+++ b/tests/cli/test_config_file.py
@@ -342,6 +342,56 @@ def test_load_sources_from_config(tmp_path: Path) -> None:
     assert bq.location == "US"
 
 
+def test_load_sources_private_key_path_resolved_relative_to_config(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "sources:",
+                "  my_sf:",
+                "    dialect: snowflake",
+                "    account: xy12345.us-east-1.aws",
+                "    user: bob",
+                "    database: ANALYTICS",
+                "    private_key_path: ./keys/sf.pem",
+                "    private_key_passphrase: secret",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_cli_config(config_path)
+    sf = cfg.sources["my_sf"]
+    assert sf.private_key_path == (tmp_path / "keys" / "sf.pem").resolve()
+    assert sf.private_key_passphrase == "secret"
+
+
+def test_load_sources_private_key_path_keeps_absolute(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "sources:",
+                "  my_sf:",
+                "    dialect: snowflake",
+                "    account: xy12345.us-east-1.aws",
+                "    user: bob",
+                "    database: ANALYTICS",
+                f"    private_key_path: {tmp_path / 'sf.pem'}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_cli_config(config_path)
+    sf = cfg.sources["my_sf"]
+    assert sf.private_key_path == (tmp_path / "sf.pem").resolve()
+
+
 def test_sources_secrets_merge(tmp_path: Path) -> None:
     cfg_dir = tmp_path / ".pretensor"
     cfg_dir.mkdir()

--- a/tests/connectors/test_dsn_parsing.py
+++ b/tests/connectors/test_dsn_parsing.py
@@ -191,6 +191,22 @@ def test_source_snowflake_config() -> None:
     assert "PUBLIC" in cfg.schema_filter.include
 
 
+def test_source_snowflake_private_key_config() -> None:
+    src = SourceConfig(
+        dialect="snowflake",
+        account="xy12345.us-east-1.aws",
+        user="bob",
+        database="MYDB",
+        private_key_path="/keys/snowflake.pem",
+        private_key_passphrase="secret",
+    )
+    cfg = connection_config_from_source("sf1", src)
+    assert cfg.type == DatabaseType.SNOWFLAKE
+    assert cfg.private_key_path == "/keys/snowflake.pem"
+    assert cfg.private_key_passphrase == "secret"
+    assert cfg.password is None
+
+
 def test_source_bigquery_config() -> None:
     src = SourceConfig(
         dialect="bigquery", project="my-project", dataset="analytics",

--- a/tests/connectors/test_snowflake_connector.py
+++ b/tests/connectors/test_snowflake_connector.py
@@ -1055,3 +1055,143 @@ class TestPrimaryKeyCache:
         connector = _make_connector()
         result = connector._load_check_constraints_for_table("TPCH_SF1", "ORDERS")
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: private key authentication
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateKeyAuth:
+    def test_url_omits_password_when_private_key_set(self) -> None:
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            user="alice",
+            password="secret",
+            private_key_path="/some/key.pem",
+        )
+        connector = SnowflakeConnector(cfg)
+        url = connector._snowflake_url()
+
+        assert "secret" not in url
+        assert "snowflake://alice@acct/DB" in url
+
+    def test_load_private_key_file_not_found(self) -> None:
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            private_key_path="/nonexistent/key.pem",
+        )
+        connector = SnowflakeConnector(cfg)
+        with pytest.raises(SnowflakeConnectorError, match="not found"):
+            connector._load_private_key()
+
+    def test_load_private_key_invalid_format(self, tmp_path: Path) -> None:
+        bad_key = tmp_path / "bad.pem"
+        bad_key.write_text("not a valid key", encoding="utf-8")
+
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            private_key_path=str(bad_key),
+        )
+        connector = SnowflakeConnector(cfg)
+        with pytest.raises(SnowflakeConnectorError, match="Failed to parse"):
+            connector._load_private_key()
+
+    def test_load_private_key_success(self, tmp_path: Path) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        key_file = tmp_path / "key.pem"
+        key_file.write_bytes(pem)
+
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            private_key_path=str(key_file),
+        )
+        connector = SnowflakeConnector(cfg)
+        pkb = connector._load_private_key()
+
+        assert isinstance(pkb, bytes)
+        assert len(pkb) > 0
+
+    def test_load_private_key_with_passphrase(self, tmp_path: Path) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(b"my-pass"),
+        )
+        key_file = tmp_path / "key.pem"
+        key_file.write_bytes(pem)
+
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            private_key_path=str(key_file),
+            private_key_passphrase="my-pass",
+        )
+        connector = SnowflakeConnector(cfg)
+        pkb = connector._load_private_key()
+
+        assert isinstance(pkb, bytes)
+        assert len(pkb) > 0
+
+    def test_load_private_key_wrong_passphrase(self, tmp_path: Path) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(b"my-pass"),
+        )
+        key_file = tmp_path / "key.pem"
+        key_file.write_bytes(pem)
+
+        from pretensor.introspection.models.config import ConnectionConfig
+
+        cfg = ConnectionConfig(
+            name="x",
+            type=DatabaseType.SNOWFLAKE,
+            host="acct",
+            database="DB",
+            private_key_path=str(key_file),
+            private_key_passphrase="wrong-pass",
+        )
+        connector = SnowflakeConnector(cfg)
+        with pytest.raises(SnowflakeConnectorError, match="Failed to parse"):
+            connector._load_private_key()

--- a/uv.lock
+++ b/uv.lock
@@ -1241,7 +1241,7 @@ wheels = [
 
 [[package]]
 name = "pretensor"
-version = "0.1.0a2"
+version = "0.1.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Resolves PRE-670

Files Modified
1. src/pretensor/introspection/models/config.py
- Added private_key_path: str | None = None and private_key_passphrase: str | None = None to ConnectionConfig.
2. src/pretensor/cli/config_file.py
- Added private_key_path and private_key_passphrase to SourceConfig and the _SOURCE_ALLOWED_KEYS allowlist.
- Updated _source_config_from_mapping to resolve private_key_path relative to the config file's directory (using the existing _resolved_optional_path helper), with absolute paths preserved as-is.
- Threaded base_dir through _parse_sources into _source_config_from_mapping.
3. src/pretensor/introspection/models/dsn.py
- Updated connection_config_from_source for Snowflake to pass through private_key_path and private_key_passphrase from SourceConfig into ConnectionConfig.
4. src/pretensor/connectors/snowflake.py
- Added cryptography.hazmat imports for PEM key parsing and DER serialization.
- _snowflake_url(): Implements strict precedence logic — when private_key_path is configured, the password is omitted from the connection URL entirely.
- _load_private_key(): Reads the key file, handles missing files (FileNotFoundError) and OS errors, parses/decrypts the PEM key using the optional passphrase, and serializes it to DER-encoded PKCS8 bytes as required by Snowflake's Python connector.
- connect(): Passes connect_args={'private_key': pkb} to create_engine when key-based auth is configured.
Tests Added/Updated
- tests/connectors/test_snowflake_connector.py — 6 new tests covering:
- URL omits password when private key is set
- FileNotFoundError → clean SnowflakeConnectorError
- Invalid key format → clean SnowflakeConnectorError
- Successful loading of unencrypted and encrypted keys
- Wrong passphrase → clean SnowflakeConnectorError
- tests/connectors/test_dsn_parsing.py — 1 new test verifying connection_config_from_source passes through key fields.
- tests/cli/test_config_file.py — 2 new tests verifying:
- Relative private_key_path is resolved against the config file location
- Absolute private_key_path is preserved unchanged